### PR TITLE
Changes to accomodate usage as a git submodule.

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -17,22 +17,29 @@ const which = require('npm-which')(execArgs.cwd);
 // Argument parsing
 const args = new Set(process.argv.slice(2));
 if (args.has('-h') || args.has('--help')) {
-  console.log('Usage: ./build.js [--watch|-w]')
-  console.log('  --watch  -w  rebuild UI artifacts with every change to webui/webapp/app/**/*');
-  console.log('  --server -s  run a local server for development purposes');
+  console.log('Usage: ./build.js [OPTIONS]')
+  console.log('Options: ')
+  console.log('  --watch  -w          rebuild UI artifacts with every change to webui/webapp/app/**/*');
+  console.log('  --server -s          run a local server for development purposes');
+  console.log('  --skipInitial, -si   if specified with --watch, the first build is skipped');
   process.exit(0);
 }
 const isWatchTarget = args.has('--watch') || args.has('-w');
+const shouldSkipFirstBuild = isWatchTarget && (args.has('--skipInitial') || args.has('-si'));
 
 // Build n' bundle the JS and CSS
-compileJavascript();
-bundleJavascript();
-compileLess();
+if (!shouldSkipFirstBuild) {
+  compileJavascript();
+  bundleJavascript();
+  compileLess();
 
-// If we're building a production asset, minify the JS. We always minfiy the CSS given that
-// the web inspector makes it easy to debug the CSS rules that are applied.
-if (process.env.NODE_ENV === 'production') {
-  minifyJavascriptBundle();
+  // If we're building a production asset, minify the JS. We always minfiy the CSS given that
+  // the web inspector makes it easy to debug the CSS rules that are applied.
+  if (process.env.NODE_ENV === 'production') {
+    minifyJavascriptBundle();
+  }
+} else {
+  console.log(chalk.yellow('skipping first build, as --skipInitial was passed'));
 }
 
 // Local developers run the watch target, which watches the files in src/ for changes and updates

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "node ./bin/build.js",
     "watch": "node ./bin/build.js --watch",
     "start": "node ./bin/build.js --server --watch",
-    "prepublish": "npm run clean && NODE_ENV==production && npm run build",
+    "prepublishOnly": "npm run clean && NODE_ENV==production && npm run build",
     "test": "mocha --compilers js:babel-core/register 'src/**/*.test.js'",
     "clean": "rm -rf dist/"
   },


### PR DESCRIPTION
* Add the `--skipInitial` flag, which instructs the watch target to
  skip the first build.
* Change the `prepublish` hook to `prepublishOnly`. This prevents
  a circular loop when the dependency is "installed" via a local
  npm dependency (when it's loaded as a git submodule).

@aaronsarnat Please review.