### PR TITLE
Scrollfix

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -17,7 +17,6 @@
       #tree {
         display: flex;
         flex-direction: column;
-        flex-grow: 1;
       }
 
       .hpdev__select-tree {

--- a/dev/index.html
+++ b/dev/index.html
@@ -17,6 +17,7 @@
       #tree {
         display: flex;
         flex-direction: column;
+        flex-grow: 1;
       }
 
       .hpdev__select-tree {

--- a/dev/index.html
+++ b/dev/index.html
@@ -4,16 +4,19 @@
     <link rel="stylesheet" href="static/hierplane.min.css">
     <style>
       html, body {
-        display: flex;
-        flex-direction: column;
         height: 100%;
         width: 100%;
-        padding: 0;
+      }
+
+      body {
+        display: flex;
+        flex-direction: column;
         margin: 0;
       }
 
       #tree {
         display: flex;
+        flex-direction: column;
         flex-grow: 1;
       }
 


### PR DESCRIPTION
Short story, this PR fixes [Top-level scrolling is broken #30](https://github.com/allenai/hierplane/issues/30)

Long story, this PR:

- Adds the `flex-direction: column;` style to `#tree` which fixes the scrolling issue.
- Takes `padding: 0` style out of `html, body` since neither element has any default padding that needs to be overridden.
- moves flex and margin styles to a `body` rule, as they are unnecessary for `html`.