### PR TITLE
adding gitignore to gh-pages branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules


### PR DESCRIPTION
@codeviking this is a real PR, as `dist/` and `node_modules/` were lingering after I switched branches.