### PR TITLE
Preserve the spanType, if provided by end users.

### DIFF
--- a/dev/data/the-sum-of-three-consecutive-integers.json
+++ b/dev/data/the-sum-of-three-consecutive-integers.json
@@ -11,6 +11,11 @@
           {
             "start": 42,
             "end": 46
+          },
+          {
+            "start": 46,
+            "end": 47,
+            "spanType": "ignored"
           }
         ],
         "children": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hierplane",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A javascript library for visualizing hierarchical data, specifically tailored towards rendering dependency parses.",
   "files": [
     "dist/**/*.js",

--- a/src/module/helpers.js
+++ b/src/module/helpers.js
@@ -155,7 +155,7 @@ export function translateSpans(origNode) {
           (node.spans || []).map(span => new Span(
             /* lo = */ span.start,
             /* hi = */ span.end,
-            /* spanType = */ 'self'
+            /* spanType = */ span.spanType || 'self'
           ))
         ).sort((first, second) => first.lo - second.lo);
 

--- a/src/module/helpers.test.js
+++ b/src/module/helpers.test.js
@@ -220,5 +220,17 @@ describe('assignNodeIds', () => {
       };
       expect(translateSpans(treeWithSpans)).to.deep.equal(expectedTranslatedTree);
     });
+
+    it('preserves the type of a user provided span', () => {
+        const treeWithSpans = {
+          spans: [
+            { start: 10, end: 13 },
+            { start: 14, end: 15, spanType: 'ignored' }
+          ]
+        };
+        const { alternateParseInfo: { spanAnnotations } } = translateSpans(treeWithSpans);
+        expect(spanAnnotations[0].spanType).to.equal("self");
+        expect(spanAnnotations[1].spanType).to.equal("ignored");
+    });
   })
 });


### PR DESCRIPTION
This makes it possible for end users (i.e. me integrating it into
AllenNLP) to provide a `spanType`, which is helpful for rendering
punctuation.

We'll likely need to document this in the README, but I'll leave that
for later.

I also bumped the version, since I'll publish another rev so I can
pull it into AllenNLP.