### PR TITLE
Always assign node ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hierplane",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A javascript library for visualizing hierarchical data, specifically tailored towards rendering dependency parses.",
   "files": [
     "dist/**/*.js",

--- a/src/module/Tree.js
+++ b/src/module/Tree.js
@@ -109,10 +109,6 @@ class Tree extends Component {
     this.setCollapsible = this.setCollapsible.bind(this);
     this.populateData = this.populateData.bind(this);
     this.populateError = this.populateError.bind(this);
-
-    if (this.props.tree) {
-      this.props.tree.root = translateSpans(assignNodeIds(this.props.tree.root));
-    }
   }
 
   componentDidMount() {
@@ -241,6 +237,9 @@ class Tree extends Component {
       this.fetchData(fetchPath, "get", {}, false);
     } else {
       // Load static data
+      if (this.props.tree) {
+        this.props.tree.root = translateSpans(assignNodeIds(this.props.tree.root));
+      }
       const { fetchedData, selectedData } = this.sanitizeResponse(this.props.tree, false);
       this.populateData(fetchedData, "", selectedData);
     }


### PR DESCRIPTION
This makes it possible to re-render the tree without remounting
the component, which is required for embedding the application
in a react application.