### PR TITLE
Ignore Jekyll generated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 node_modules
 npm-debug.log
+.sass-cache
+_site


### PR DESCRIPTION
These folders get generated whenever I run Jekyll locally to test changes to the `gh-pages` branch. They don't need to be in the repo (on either branch), and it would be helpful to not have to delete them every time I switch from `gh-pages` to `master`.