### PR TITLE
Sane defaults.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hierplane",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A javascript library for visualizing hierarchical data, specifically tailored towards rendering dependency parses.",
   "files": [
     "dist/**/*.js",

--- a/src/module/Tree.js
+++ b/src/module/Tree.js
@@ -33,8 +33,8 @@ class Tree extends Component {
       urlText: undefined,
       parser: 'default',
       tree: undefined,
-      readOnly: false,
-      showSidebar: true
+      readOnly: true,
+      showSidebar: false
     };
   }
 

--- a/src/static/hierplane.js
+++ b/src/static/hierplane.js
@@ -14,7 +14,7 @@ import ReactDOM from 'react-dom';
  */
 export function renderTree(tree, options = { target: 'body' }) {
   ReactDOM.render(
-    <Tree tree={tree} readOnly={true} showSidebar={false} />,
+    <Tree tree={tree} />,
     document.querySelector(options.target)
   );
 }


### PR DESCRIPTION
Set `readOnly` to `true` by default and `showSidebar` to `false`
by default.