### PR TITLE
Fixing chrome table cell content height bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hierplane",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A javascript library for visualizing hierarchical data, specifically tailored towards rendering dependency parses.",
   "files": [
     "dist/**/*.js",

--- a/src/less/explainer/ft.less
+++ b/src/less/explainer/ft.less
@@ -20,6 +20,8 @@
 }
 
 .ft--middle-parent {
+  height: 0; // TODO(aarons): see if this hack can be removed if/when Chrome addresses their table cell content height bug
+
   & > .node {
     height: 100%;
     margin-top: 0;


### PR DESCRIPTION
This PR fixes [Chrome - Disembodied Children #75](https://github.com/allenai/hierplane/issues/75)

---

The fix is somewhat of a hack, but it works. Unfortunately, Chrome very recently changed the way it renders content height inside of a table cell. In all browsers (including Chrome up until early December, 2017), setting the height of the cell to `100%` allowed you to set the height of anything inside it to `100%` and it would fill the height of the cell. Chrome no longer supports this. The fix is we need to set the cell height to `0`.

- This [fiddle](http://jsfiddle.net/4365nwyo/) illustrates the bug in chrome.
- This [fiddle](http://jsfiddle.net/1k60p6up/) illustrates the fix.

---

**How it works:** The height of the cell that has children needs to have a `height` value set that isn't `auto` and is any non-percentage-based unit. Note that any value we use here is essentially setting its minimum height to that value. If we set it to `800px` then it will be at least that tall. Setting height to `0` means it can be any height and will let the content inside it prop it open.

I suspect this is an edge-case Chromium CSS-rendering bug introduced in a recent release.