### PR TITLE
Updating superagent version to address security concern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hierplane",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A javascript library for visualizing hierarchical data, specifically tailored towards rendering dependency parses.",
   "files": [
     "dist/**/*.js",
@@ -36,7 +36,7 @@
     "merge": "1.2.0",
     "react-redux": "5.0.3",
     "redux": "3.6.0",
-    "superagent": "2.1.0"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION
From GitHub:

```
Known low severity security vulnerability detected in superagent <3.7.0 defined in package.json.
package.json update suggested: superagent ~> 3.7.0
```